### PR TITLE
Detect all Ruffle elements

### DIFF
--- a/ruffle-keep-alive.user.js
+++ b/ruffle-keep-alive.user.js
@@ -12,7 +12,7 @@
     'use strict';
 
     function isRufflePage() {
-        return document.querySelector('ruffle-player') !== null;
+        return document.querySelector('ruffle-embed, ruffle-object, ruffle-player') !== null;
     }
 
     function keepRuffleActive() {


### PR DESCRIPTION
Ruffle uses ruffle-embed and ruffle-object elements when polyfilling embed and object tags, respectively.